### PR TITLE
Chat

### DIFF
--- a/src/channel/channel.controller.ts
+++ b/src/channel/channel.controller.ts
@@ -1,9 +1,0 @@
-import { Controller, Get, Param } from '@nestjs/common';
-
-@Controller('channels')
-export class ChannelController {
-  @Get(':channelId')
-  getChannel(@Param('channelId') channelId: number) {
-    return `Channel with ID ${channelId}`;
-  }
-}

--- a/src/channel/channel.gateway.ts
+++ b/src/channel/channel.gateway.ts
@@ -42,9 +42,8 @@ export class ChannelGateway {
   /* ======= */
   @SubscribeMessage('createChannel')
   async createChannel(
-    client: Socket,
-     createGroupChannelDto: CreateChannelDto,
-  ) {
+    @ConnectedSocket() client: Socket,
+     @MessageBody() createGroupChannelDto: CreateChannelDto) {
     const user = await this.channelService.getAuthenticatedUser(client.data.uid);
     const channel = await this.channelService.createChannel(user, createGroupChannelDto);
     await client.join(`channel-${channel.id}`);
@@ -62,7 +61,7 @@ export class ChannelGateway {
   }
 
   @SubscribeMessage('leaveChannel')
-  async leaveChannel(@ConnectedSocket() client: Socket, payload: any) {
+  async leaveChannel(@ConnectedSocket() client: Socket, @MessageBody() payload: any) {
     const user = await this.channelService.getAuthenticatedUser(client.data.uid);
     await this.channelService.leaveChannel(user, payload.channelId);
     this.server.to(`channel-${payload.channelId}`).emit('leaveChannel', { channelId: payload.channelId, userId: user.uid });
@@ -71,7 +70,7 @@ export class ChannelGateway {
   }
 
   @SubscribeMessage('getAllChannels')
-  async getAllChannels(@ConnectedSocket() client: Socket, payload: any) {
+  async getAllChannels(@ConnectedSocket() client: Socket) {
     const channels = await this.channelService.getAllChannels();
     this.server.emit('getAllChannels', channels);
     return channels;
@@ -189,7 +188,7 @@ export class ChannelGateway {
   /* ==== */
 
   @SubscribeMessage('sendMessage')
-  async createMessage(@ConnectedSocket() client: Socket, @MessageBody() createMessageDto: CreateMessageDto) {
+  async createMessage(client: Socket, createMessageDto: CreateMessageDto) {
     const user = await this.channelService.getAuthenticatedUser(client.data.uid);
     const message = await this.channelService.createMessage(user, createMessageDto);
     this.server.to(`channel-${createMessageDto.channelId}`).emit('sendMessage', message);

--- a/src/channel/channel.gateway.ts
+++ b/src/channel/channel.gateway.ts
@@ -155,7 +155,7 @@ export class ChannelGateway {
     const user = await this.channelService.getAuthenticatedUser(client.data.uid);
     const targetUser = await this.channelService.getUserByUid(payload.targetUserUid);
     await this.channelService.muteMember(user, payload.channelId , targetUser.uid);
-    this.server.to(`channel-${payload.channelId}`).emit('updateMemberState', { channelId: payload.channelId, targetUser: targetUser.name });
+    this.server.to(`channel-${payload.channelId}`).emit('updateMemberState', `${targetUser.name} is muted in the channel ${payload.channelId}`);
   }
 
   @SubscribeMessage('banMember')

--- a/src/channel/channel.gateway.ts
+++ b/src/channel/channel.gateway.ts
@@ -4,8 +4,10 @@ import { AuthService } from 'src/auth/auth.service';
 import { ChannelService } from './channel.service';
 import { CreateChannelDto } from './dto/create-channel.dto';
 import { CreateMessageDto } from './dto/create-message.dto';
-import { ChannelUserGuard } from './guards/channel-user.guard';
-import { UseGuards } from '@nestjs/common';
+
+interface UserSocketMap {
+  [userId: string]: Socket;
+}
 
 @WebSocketGateway({
   namespace: 'channels', 
@@ -22,21 +24,18 @@ export class ChannelGateway {
   @WebSocketServer()
   server: Server;
 
-  async handleConnection(client: Socket) {
-    const payload = await this.authService.validateAccessToken(client.handshake.headers.authorization);
-    if (!payload) {
-      client.disconnect(true);
-      return;
-    }
-    const user = await this.channelService.getAuthenticatedUser(payload.uid);
-    if (!user) {
-      client.disconnect(true);
-      return;
-    }
-    client.data = { uid: user.uid };
-    console.log(`Client connected: ${user.name}`);
-  }
+  private userSocketMap: UserSocketMap = {};
 
+  async handleConnection(@ConnectedSocket() client: Socket) {
+    const payload = await this.authService.validateSocket(client);
+    if (!payload) {
+      client.disconnect();
+      return;
+    }
+    if (client.data.uid) {
+      this.userSocketMap[client.data.uid] = client;
+    }
+  }
 
   /* ======= */
   /* Channel */
@@ -48,9 +47,8 @@ export class ChannelGateway {
   ) {
     const user = await this.channelService.getAuthenticatedUser(client.data.uid);
     const channel = await this.channelService.createChannel(user, createGroupChannelDto);
-    console.log('Channel created with ID:', channel.id);
-    this.server.emit('channelEntered', { channelId: channel.id });
-    console.log('entered:', channel);
+    await client.join(`channel-${channel.id}`);
+    this.server.emit('createChannel', channel);
     return channel;
   }
 
@@ -58,23 +56,18 @@ export class ChannelGateway {
   async enterChannel(@ConnectedSocket() client: Socket, @MessageBody() payload: any) {
     const user = await this.channelService.getAuthenticatedUser(client.data.uid);
     const channel = await this.channelService.enterChannel(user, payload.channelId, payload.password);
+    console.log('channel.id: ', channel);
     await client.join(`channel-${channel.id}`);
-    this.server.emit('channelEntered', { channel: channel });
-    return channel;
+    this.server.to(`channel-${channel.id}`).emit('enterChannel', { channelId: channel.id, userId: user.id });
   }
-  
 
   @SubscribeMessage('leaveChannel')
   async leaveChannel(@ConnectedSocket() client: Socket, payload: any) {
     const user = await this.channelService.getAuthenticatedUser(client.data.uid);
     await this.channelService.leaveChannel(user, payload.channelId);
-    this.server.emit('deletedGroupChannel', {
-      channelId: payload.channelId,
-      user: {
-        id: user.id,
-        username: user.name,
-      },
-    });
+    this.server.to(`channel-${payload.channelId}`).emit('leaveChannel', { channelId: payload.channelId, userId: user.uid });
+    await client.leave(`channel-${payload.channelId}`);
+
   }
 
   @SubscribeMessage('getAllChannels')
@@ -85,73 +78,13 @@ export class ChannelGateway {
   }
 
   @SubscribeMessage('getMyChannels')
-  async getMyChannels(@ConnectedSocket() client: Socket, payload: any) {
+  async getMyChannels(@ConnectedSocket() client: Socket) {
     const user = await this.channelService.getAuthenticatedUser(client.data.uid);
     const channels = await this.channelService.getMyChannels(user);
     this.server.emit('getMyChannels', channels);
     return channels;
   }
 
-  @SubscribeMessage('getChannelMembers')
-  async getChannelMembers(@ConnectedSocket() client: Socket, payload: any) {
-    const members = await this.channelService.getChannelMembers(payload.channelId);
-    return members;
-  }
-
-  /* ====== */
-  /* Member */
-  /* ====== */
-
-  // @UseGuards(ChannelUserGuard)
-  @SubscribeMessage('getMembers')
-  async getMembers(@ConnectedSocket() client: Socket, payload: any) {
-    const members = await this.channelService.getMembers(payload.channelId);
-    return members;
-  }
-
-  // @UseGuards(ChannelUserGuard)
-  @SubscribeMessage('grantAdmin')
-  async grantAdmin(@ConnectedSocket() client: Socket, payload: any) {
-    const user = await this.channelService.getAuthenticatedUser(client.data.uid);
-    await this.channelService.grantAdmin(user, payload.channelId , payload.targetUserId);
-  }
-
-  // @UseGuards(ChannelUserGuard)
-  @SubscribeMessage('revokeAdmin')
-  async revokeAdmin(@ConnectedSocket() client: Socket, payload: any) {
-    const user = await this.channelService.getAuthenticatedUser(client.data.uid);
-    await this.channelService.revokeAdmin(user, payload.channelId , payload.targetUserId);
-  }
-
-  // @UseGuards(ChannelUserGuard)
-  @SubscribeMessage('muteMember')
-  async muteMember(@ConnectedSocket() client: Socket, payload: any) {
-    const user = await this.channelService.getAuthenticatedUser(client.data.uid);
-    await this.channelService.muteMember(user, payload.channelId , payload.targetUserId);
-  }
-
-  // @UseGuards(ChannelUserGuard)
-  @SubscribeMessage('banMember')
-  async banMember(@ConnectedSocket() client: Socket, payload: any) {
-    const user = await this.channelService.getAuthenticatedUser(client.data.uid);
-    await this.channelService.banMember(user, payload.channelId , payload.targetUserId);
-  }
-
-  // @UseGuards(ChannelUserGuard)
-  @SubscribeMessage('unbanMember')
-  async unbanMember(@ConnectedSocket() client: Socket, payload: any) {
-    const user = await this.channelService.getAuthenticatedUser(client.data.uid);
-    await this.channelService.unbanMember(user, payload.channelId , payload.targetUserId);
-  }
-
-  // @UseGuards(ChannelUserGuard)
-  @SubscribeMessage('kickMember')
-  async kickMember(@ConnectedSocket() client: Socket, payload: any) {
-    const user = await this.channelService.getAuthenticatedUser(client.data.uid);
-    await this.channelService.kickMember(user, payload.channelId , payload.targetUserId);
-  }
-
-  // @UseGuards(ChannelUserGuard)
   @SubscribeMessage('editTitle')
   async editTitle(@ConnectedSocket() client: Socket, @MessageBody() payload: any) {
     const user = await this.channelService.getAuthenticatedUser(client.data.uid);
@@ -159,7 +92,6 @@ export class ChannelGateway {
     this.server.emit('editChannel', channel);
   }
 
-  // @UseGuards(ChannelUserGuard)
   @SubscribeMessage('editPassword')
   async editPassword(@ConnectedSocket() client: Socket, @MessageBody() payload: any) {
     const user = await this.channelService.getAuthenticatedUser(client.data.uid);
@@ -167,12 +99,82 @@ export class ChannelGateway {
     this.server.emit('editChannel', channel);
   }
 
-  // @UseGuards(ChannelUserGuard)
   @SubscribeMessage('editMode')
   async editMode(@ConnectedSocket() client: Socket, @MessageBody() payload: any) {
     const user = await this.channelService.getAuthenticatedUser(client.data.uid);
     const channel = await this.channelService.editMode(user, payload.channelId , payload.mode, payload.password);
     this.server.emit('editChannel', channel);
+  }
+
+  /* ====== */
+  /* Member */
+  /* ====== */
+
+  @SubscribeMessage('getChannelMembers')
+  async getChannelMembers(@ConnectedSocket() client: Socket, @MessageBody() payload: any) {
+    const members = await this.channelService.getChannelMembers(payload.channelId);
+    this.server.emit('getChannelMembers', members);
+    return members;
+  }
+
+  @SubscribeMessage('grantAdmin')
+  async grantAdmin(@ConnectedSocket() client: Socket, payload: any) {
+    const user = await this.channelService.getAuthenticatedUser(client.data.uid);
+    await this.channelService.grantAdmin(user, payload.channelId , payload.targetUserId);
+  }
+
+  @SubscribeMessage('revokeAdmin')
+  async revokeAdmin(@ConnectedSocket() client: Socket, payload: any) {
+    const user = await this.channelService.getAuthenticatedUser(client.data.uid);
+    await this.channelService.revokeAdmin(user, payload.channelId , payload.targetUserId);
+  }
+
+  @SubscribeMessage('muteMember')
+  async muteMember(@ConnectedSocket() client: Socket, payload: any) {
+    const user = await this.channelService.getAuthenticatedUser(client.data.uid);
+    await this.channelService.muteMember(user, payload.channelId , payload.targetUserId);
+  }
+
+  @SubscribeMessage('banMember')
+  async banMember(@ConnectedSocket() client: Socket, payload: any) {
+    const user = await this.channelService.getAuthenticatedUser(client.data.uid);
+    await this.channelService.banMember(user, payload.channelId , payload.targetUserId);
+  }
+
+  @SubscribeMessage('unbanMember')
+  async unbanMember(@ConnectedSocket() client: Socket, payload: any) {
+    const user = await this.channelService.getAuthenticatedUser(client.data.uid);
+    await this.channelService.unbanMember(user, payload.channelId , payload.targetUserId);
+  }
+
+  @SubscribeMessage('kickMember')
+  async kickMember(@ConnectedSocket() client: Socket, payload: any) {
+    const user = await this.channelService.getAuthenticatedUser(client.data.uid);
+    await this.channelService.kickMember(user, payload.channelId , payload.targetUserId);
+    const targetUserSocket = this.server.sockets.sockets.get(payload.targetUserId);
+    if (targetUserSocket) {
+      targetUserSocket.leave(`channel-${payload.channelId}`);
+      targetUserSocket.emit('kickChannel', { channelId: payload.channelId, userId: payload.targetUserId });
+    }
+
+  }
+
+  @SubscribeMessage('inviteUserToChannel')
+  async inviteUserToChannel(@ConnectedSocket() client: Socket, @MessageBody() payload: any) {
+    const user = await this.channelService.getAuthenticatedUser(client.data.uid);
+    const targetUser = await this.channelService.getUserByUid(payload.targetUid);
+
+    // await this.channelService.inviteUserToChannel(user, payload.channelId , targetUser);
+    const targetUserSocket = this.userSocketMap[payload.targetUid];
+
+
+    console.log('targetUserSocket', targetUserSocket)
+
+    // if (targetUserSocket) {
+    //   targetUserSocket.join(`channel-${payload.channelId}`);
+    //   targetUserSocket.emit('enterChannel', { channelId: payload.channelId, userId: payload.targetId });
+    // }
+    this.server.emit('inviteUserToChannel', targetUser);
   }
 
 
@@ -184,7 +186,7 @@ export class ChannelGateway {
   @SubscribeMessage('sendMessage')
   async createMessage(@ConnectedSocket() client: Socket, @MessageBody() data: CreateMessageDto) {
     const message = await this.channelService.createMessage(client.data.uid, data.channelId, data.content);
-    this.server.to(`channel-${data.channelId}`).emit('newMessage', message);
+    this.server.to(`channel-${data.channelId}`).emit('sendMessage', message);
     return message;
   }
 }

--- a/src/channel/channel.module.ts
+++ b/src/channel/channel.module.ts
@@ -8,7 +8,6 @@ import { Cm } from './entities/cm.entity';
 import { ChannelService } from './channel.service';
 import { ChannelUser } from './entities';
 import { ChannelUserGuard } from './guards/channel-user.guard';
-import { ChannelController } from './channel.controller';
 
 @Module({
   imports: [
@@ -21,6 +20,5 @@ import { ChannelController } from './channel.controller';
     AuthModule,
   ],
   providers: [ChannelGateway, ChannelService, ChannelUserGuard],
-  controllers: [ChannelController]
 })
 export class ChannelModule {}

--- a/src/channel/channel.service.ts
+++ b/src/channel/channel.service.ts
@@ -12,7 +12,6 @@ import { AlreadyPresentExeption, InvalidPasswordException, MissingPasswordExcept
 from 'src/common/exceptions/chat.exception';
 import { Cm } from './entities/cm.entity';
 import { CreateMessageDto } from './dto/create-message.dto';
-import { create } from 'domain';
 
 @Injectable()
 export class ChannelService {
@@ -112,7 +111,7 @@ export class ChannelService {
   /* ======= */
   async createChannel(
     creator: User,
-    createChannelDto: CreateChannelDto,
+    createChannelDto: any,
   ): Promise<Channel> {
     const groupChannel: Channel = new Channel();
     groupChannel.title = createChannelDto.title;
@@ -424,7 +423,6 @@ export class ChannelService {
   /* ==== */
 
   async createMessage(user: User, createMessageDto: CreateMessageDto): Promise<Cm | undefined> {
-    console.log(createMessageDto.content);
     const channel = await this.validateChannelAndMember(user, createMessageDto.channelId);
     const sender = await this.getChannelUser(user.id, channel.id);
     if (await this.isMemberMuted(user, channel.id)) {
@@ -439,6 +437,7 @@ export class ChannelService {
       timeStamp: new Date(),
     });
     await this.cmRepository.save(message)
+    console.log('message:', message);
     return message;
   }
 

--- a/src/channel/dto/create-channel.dto.ts
+++ b/src/channel/dto/create-channel.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, IsOptional, IsEnum, IsInt } from 'class-validator';
+import { IsString, IsNotEmpty, IsOptional, IsEnum } from 'class-validator';
 import { ChannelMode } from '../enum/channelMode.enum';
 
 export class CreateChannelDto {

--- a/src/channel/dto/create-message.dto.ts
+++ b/src/channel/dto/create-message.dto.ts
@@ -1,7 +1,8 @@
-import { IsNotEmpty, IsString } from "class-validator";
+import { IsInt, IsNotEmpty, IsString } from "class-validator";
 
 export class CreateMessageDto {
 	@IsNotEmpty()
+	@IsInt()
 	channelId: number;
 
 	@IsNotEmpty()

--- a/src/channel/entities/channel.entity.ts
+++ b/src/channel/entities/channel.entity.ts
@@ -1,6 +1,7 @@
 import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, OneToMany, IntegerType } from 'typeorm';
 import { ChannelMode } from '../enum/channelMode.enum';
 import { ChannelUser } from './channelUser.entity';
+import { Cm } from './cm.entity';
 
 @Entity()
 export class Channel {
@@ -9,6 +10,9 @@ export class Channel {
 
   @OneToMany(() => ChannelUser, (channelUser) => channelUser.channel)
   channelUser: ChannelUser[];
+
+  @OneToMany(() => Cm, (cm) => cm.channel)
+  message: Cm[];
 
   @Column({ nullable: false })
   title: string;

--- a/src/channel/entities/channel.entity.ts
+++ b/src/channel/entities/channel.entity.ts
@@ -24,4 +24,7 @@ export class Channel {
 
   @Column("int", { array: true, nullable: true })
   banned_uid: number[];
+
+  @Column("int", { array: true, nullable: true })
+  muted_uid: number[];
 }

--- a/src/channel/entities/channel.entity.ts
+++ b/src/channel/entities/channel.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, OneToMany } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, OneToMany, IntegerType } from 'typeorm';
 import { ChannelMode } from '../enum/channelMode.enum';
 import { ChannelUser } from './channelUser.entity';
 
@@ -21,4 +21,7 @@ export class Channel {
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
+
+  @Column("int", { array: true, nullable: true })
+  banned_uid: number[];
 }

--- a/src/channel/entities/channelUser.entity.ts
+++ b/src/channel/entities/channelUser.entity.ts
@@ -14,9 +14,6 @@ export class ChannelUser {
   @JoinColumn()
   user: User;
 
-  @OneToMany(() => Cm, (cm) => cm.sender)
-  message: Cm[]; 
-
   @ManyToOne(() => Channel, (channel) => channel.channelUser)
   @JoinColumn()
   channel: Channel;

--- a/src/channel/entities/channelUser.entity.ts
+++ b/src/channel/entities/channelUser.entity.ts
@@ -26,7 +26,4 @@ export class ChannelUser {
 
   @Column({ nullable: false, default: ChannelRole.NORMAL })
   role: ChannelRole;
-
-  @Column({ nullable: false, default: false })
-  is_muted: boolean;
 }

--- a/src/channel/entities/channelUser.entity.ts
+++ b/src/channel/entities/channelUser.entity.ts
@@ -14,7 +14,7 @@ export class ChannelUser {
   @JoinColumn()
   user: User;
 
-  @OneToMany(() => Cm, (cm) => cm.channelUser)
+  @OneToMany(() => Cm, (cm) => cm.sender)
   message: Cm[]; 
 
   @ManyToOne(() => Channel, (channel) => channel.channelUser)
@@ -29,7 +29,4 @@ export class ChannelUser {
 
   @Column({ nullable: false, default: false })
   is_muted: boolean;
-
-  @Column({ nullable: false, default: false })
-  is_banned: boolean;
 }

--- a/src/channel/entities/cm.entity.ts
+++ b/src/channel/entities/cm.entity.ts
@@ -7,7 +7,7 @@ export class Cm extends BaseEntity {
   id: number;
 
   @ManyToOne(() => ChannelUser, (channelUser) => channelUser.message)
-  channelUser: ChannelUser;
+  sender: ChannelUser;
 
   @Column('text', { nullable: false })
   content: string;

--- a/src/channel/entities/cm.entity.ts
+++ b/src/channel/entities/cm.entity.ts
@@ -1,16 +1,17 @@
 import { Entity, Column, ManyToOne, PrimaryGeneratedColumn, BaseEntity, CreateDateColumn } from 'typeorm';
 import { ChannelUser } from './channelUser.entity';
+import { Channel } from './channel.entity';
 
 @Entity({ name: 'cm' })
 export class Cm extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ManyToOne(() => ChannelUser, (channelUser) => channelUser.message)
-  sender: ChannelUser;
+  @ManyToOne(() => Channel, (channel) => channel.message)
+  channel: Channel;
   
   @Column('int', { nullable: false })
-  channelId: number;
+  sender_uid: number;
 
   @Column('text', { nullable: false })
   content: string;

--- a/src/channel/entities/cm.entity.ts
+++ b/src/channel/entities/cm.entity.ts
@@ -8,6 +8,9 @@ export class Cm extends BaseEntity {
 
   @ManyToOne(() => ChannelUser, (channelUser) => channelUser.message)
   sender: ChannelUser;
+  
+  @Column('int', { nullable: false })
+  channelId: number;
 
   @Column('text', { nullable: false })
   content: string;

--- a/src/common/exceptions/chat.exception.ts
+++ b/src/common/exceptions/chat.exception.ts
@@ -23,3 +23,9 @@ export class NotAuthorizedException extends HttpException {
     super(message, HttpStatus.UNAUTHORIZED);
   }
 }
+
+export class AlreadyPresentExeption extends HttpException {
+  constructor(message: string) {
+    super(message, HttpStatus.UNAUTHORIZED);
+  }
+}


### PR DESCRIPTION
getMember할 때 role별로 정렬
owner 나가면 owner물려주기?
비밀번호 알고리즘
channelMode에 따라 입장여부 → private만 막으면 될듯(초대할때)
상태(ban, mute)에 따라 [입장, 채팅, 초대] 제한되게 가드 추가하기
채널 멤버수 제한
banlist만드는걸로 수정
user를 channel에 초대하기 → 테스트중
사용자 입장, 퇴장, 뮤트, 밴, 킥 알리는 메세지 만들기
채팅테스트
대화내용 불러오기
메세지로그 저장