### PR TITLE
Chat (#20)

### DIFF
--- a/src/channel/channel.controller.ts
+++ b/src/channel/channel.controller.ts
@@ -1,9 +1,0 @@
-import { Controller, Get, Param } from '@nestjs/common';
-
-@Controller('channels')
-export class ChannelController {
-  @Get(':channelId')
-  getChannel(@Param('channelId') channelId: number) {
-    return `Channel with ID ${channelId}`;
-  }
-}

--- a/src/channel/channel.module.ts
+++ b/src/channel/channel.module.ts
@@ -8,7 +8,6 @@ import { Cm } from './entities/cm.entity';
 import { ChannelService } from './channel.service';
 import { ChannelUser } from './entities';
 import { ChannelUserGuard } from './guards/channel-user.guard';
-import { ChannelController } from './channel.controller';
 
 @Module({
   imports: [
@@ -21,6 +20,5 @@ import { ChannelController } from './channel.controller';
     AuthModule,
   ],
   providers: [ChannelGateway, ChannelService, ChannelUserGuard],
-  controllers: [ChannelController]
 })
 export class ChannelModule {}

--- a/src/channel/dto/create-channel.dto.ts
+++ b/src/channel/dto/create-channel.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, IsOptional, IsEnum, IsInt } from 'class-validator';
+import { IsString, IsNotEmpty, IsOptional, IsEnum } from 'class-validator';
 import { ChannelMode } from '../enum/channelMode.enum';
 
 export class CreateChannelDto {

--- a/src/channel/dto/create-message.dto.ts
+++ b/src/channel/dto/create-message.dto.ts
@@ -1,7 +1,8 @@
-import { IsNotEmpty, IsString } from "class-validator";
+import { IsInt, IsNotEmpty, IsString } from "class-validator";
 
 export class CreateMessageDto {
 	@IsNotEmpty()
+	@IsInt()
 	channelId: number;
 
 	@IsNotEmpty()

--- a/src/channel/entities/channel.entity.ts
+++ b/src/channel/entities/channel.entity.ts
@@ -1,6 +1,7 @@
-import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, OneToMany } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, OneToMany, IntegerType } from 'typeorm';
 import { ChannelMode } from '../enum/channelMode.enum';
 import { ChannelUser } from './channelUser.entity';
+import { Cm } from './cm.entity';
 
 @Entity()
 export class Channel {
@@ -9,6 +10,9 @@ export class Channel {
 
   @OneToMany(() => ChannelUser, (channelUser) => channelUser.channel)
   channelUser: ChannelUser[];
+
+  @OneToMany(() => Cm, (cm) => cm.channel)
+  message: Cm[];
 
   @Column({ nullable: false })
   title: string;
@@ -21,4 +25,10 @@ export class Channel {
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
+
+  @Column("int", { array: true, nullable: true })
+  banned_uid: number[];
+
+  @Column("int", { array: true, nullable: true })
+  muted_uid: number[];
 }

--- a/src/channel/entities/channelUser.entity.ts
+++ b/src/channel/entities/channelUser.entity.ts
@@ -14,9 +14,6 @@ export class ChannelUser {
   @JoinColumn()
   user: User;
 
-  @OneToMany(() => Cm, (cm) => cm.channelUser)
-  message: Cm[]; 
-
   @ManyToOne(() => Channel, (channel) => channel.channelUser)
   @JoinColumn()
   channel: Channel;
@@ -26,10 +23,4 @@ export class ChannelUser {
 
   @Column({ nullable: false, default: ChannelRole.NORMAL })
   role: ChannelRole;
-
-  @Column({ nullable: false, default: false })
-  is_muted: boolean;
-
-  @Column({ nullable: false, default: false })
-  is_banned: boolean;
 }

--- a/src/channel/entities/cm.entity.ts
+++ b/src/channel/entities/cm.entity.ts
@@ -1,13 +1,17 @@
 import { Entity, Column, ManyToOne, PrimaryGeneratedColumn, BaseEntity, CreateDateColumn } from 'typeorm';
 import { ChannelUser } from './channelUser.entity';
+import { Channel } from './channel.entity';
 
 @Entity({ name: 'cm' })
 export class Cm extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ManyToOne(() => ChannelUser, (channelUser) => channelUser.message)
-  channelUser: ChannelUser;
+  @ManyToOne(() => Channel, (channel) => channel.message)
+  channel: Channel;
+  
+  @Column('int', { nullable: false })
+  sender_uid: number;
 
   @Column('text', { nullable: false })
   content: string;

--- a/src/common/exceptions/chat.exception.ts
+++ b/src/common/exceptions/chat.exception.ts
@@ -23,3 +23,9 @@ export class NotAuthorizedException extends HttpException {
     super(message, HttpStatus.UNAUTHORIZED);
   }
 }
+
+export class AlreadyPresentExeption extends HttpException {
+  constructor(message: string) {
+    super(message, HttpStatus.UNAUTHORIZED);
+  }
+}


### PR DESCRIPTION
* refined all method in Chat

- getMember할 때 role별로 정렬
- owner 나가면 owner물려주기?
- 비밀번호 알고리즘
- channelMode에 따라 입장여부 → private만 막으면 될듯(초대할때)
- 상태(ban, mute)에 따라 [입장, 채팅, 초대] 제한되게 가드 추가하기
- 채널 멤버수 제한
- banlist만드는걸로 수정
- user를 channel에 초대하기 → 테스트중
- 사용자 입장, 퇴장, 뮤트, 밴, 킥 알리는 메세지 만들기
- 채팅테스트
- 대화내용 불러오기
- 메세지로그 저장